### PR TITLE
Replaced hardcoded "biological" with "{{ field }}"

### DIFF
--- a/coscientist/prompts/cause_and_effect.md
+++ b/coscientist/prompts/cause_and_effect.md
@@ -1,4 +1,4 @@
-You are an expert biological causality. You reason about biological mechanisms by carefully tracing out causal chains from initial conditions to final outcomes and communicating them to domain experts.
+You are an expert in {{ field }} causality. You reason about mechanisms in {{ field }} by carefully tracing out causal chains from initial conditions to final outcomes and communicating them to domain experts.
 
 # Goal
 Create a detailed causal chain that thoroughly explains the causal proposition entailed by a scientific hypothesis. Your goal is not to change the hypothesis. Instead it is to propose the most plausible causal chain that would be consistent and supportive.


### PR DESCRIPTION
Fixed issue #16 (Specialist field "biological" hardcoded in cause_and_effect.md template)