### PR TITLE
Fix for calculation of the number of ranked hypotheses

### DIFF
--- a/app/meta_reviews_page.py
+++ b/app/meta_reviews_page.py
@@ -117,8 +117,8 @@ def display_meta_reviews_page(state):
                                 f"• Hypotheses in Tournament: {len(tournament.hypotheses)}"
                             )
                         try:
-                            win_loss_records = tournament.get_win_loss_records()
-                            st.write(f"• Ranked Hypotheses: {len(win_loss_records)}")
+                            ranked_hypotheses = tournament.get_ranked_hypotheses()
+                            st.write(f"• Ranked Hypotheses: {len(ranked_hypotheses)}")
                         except:  # noqa: E722
                             st.write("• Tournament statistics unavailable")
                     else:

--- a/coscientist/global_state.py
+++ b/coscientist/global_state.py
@@ -396,7 +396,7 @@ class CoscientistStateManager:
         ranked_order = self._state.tournament.get_sorted_hypotheses()
         # The records dictionary tells us which hypotheses have competed
         # already and are therefore qualified for evolution.
-        have_competed = self._state.tournament.get_win_loss_records().keys()
+        have_competed = self._state.tournament.get_ranked_hypotheses()
 
         return [h_id for h_id, _ in ranked_order if h_id in have_competed]
 
@@ -479,7 +479,7 @@ class CoscientistStateManager:
         Get the number of hypotheses that have not yet been ranked in the tournament.
         """
         return len(self._state.tournament.hypotheses) - len(
-            self._state.tournament.get_win_loss_records()
+            self._state.tournament.get_ranked_hypotheses()
         )
 
     @property
@@ -576,7 +576,7 @@ class CoscientistStateManager:
         """
         self._state.meta_reviews.append(meta_review)
         self._state.num_ranked_hypotheses_at_meta_review = len(
-            self._state.tournament.get_win_loss_records()
+            self._state.tournament.get_ranked_hypotheses()
         )
 
     @_maybe_save(n=1)
@@ -997,7 +997,7 @@ class CoscientistStateManager:
 
         # Calculate new hypotheses since last meta-review
         current_ranked_hypotheses = (
-            len(self._state.tournament.get_win_loss_records())
+            len(self._state.tournament.get_ranked_hypotheses())
             if self._state.tournament
             else 0
         )

--- a/coscientist/ranking_agent.py
+++ b/coscientist/ranking_agent.py
@@ -351,6 +351,24 @@ class EloTournament:
 
         return records
 
+    def get_ranked_hypotheses(self) -> list[str]:
+        """
+        Returns a list containing the ID of every ranked hypothesis.
+
+        Returns
+        -------
+        list[str]
+            A list where each entry is the hypothesis ID of a ranked hypothesis.
+        """
+        win_loss_records = self.get_win_loss_records()
+
+        ranked_hypotheses = []
+        for h_id in self.hypotheses.keys():
+            if {"wins": 0, "losses": 0} != win_loss_records[h_id]:
+                ranked_hypotheses.append(h_id)
+
+        return ranked_hypotheses
+
     def summarize_tournament_trajectory(self) -> str:
         """
         Summarizes the trajectory of the tournament for the supervisor agent.


### PR DESCRIPTION
As described in issue #21, the length of the dict returned from [get_win_loss_records()](https://github.com/conradry/open-coscientist-agents/blob/main/coscientist/ranking_agent.py#L329) is used in several places in which the number of ranked hypotheses is expected.

This PR fixes that, introducing a method get_ranked_hypotheses() that returns a list of the ranked hypotheses' IDs and uses this method in several places in the code where [get_win_loss_records()](https://github.com/conradry/open-coscientist-agents/blob/main/coscientist/ranking_agent.py#L329) was used.